### PR TITLE
#2 - Add CI workflow for backend linting and formatting using ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Run formatter (ruff)
+        run: ruff check . --fix && ruff format .


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting for the backend codebase. The workflow is triggered on pushes and pull requests to the `main` branch and uses `ruff` for linting and formatting Python code.

### New CI Workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R31): Added a `CI` workflow that runs a `backend-lint` job on `ubuntu-latest`. The job sets up Python 3.10, installs `ruff` as a dependency, and runs it for both linting and formatting the backend code.