### PR TITLE
#4 - Add recent entries view and template, update navigation links

### DIFF
--- a/backend/entries/templates/entries/base.html
+++ b/backend/entries/templates/entries/base.html
@@ -10,6 +10,10 @@
 
 <body>
   <h1><a href="/">LogBook …</a></h1>
+  <nav>
+    <a href="{% url 'entry-list' %}">All Entries</a>
+    <a href="{% url 'entry-recents' %}">Recent Entries</a>
+  </nav>
 
   {% if messages %}
   <ul class="messages">

--- a/backend/entries/templates/entries/entry_list_recents.html
+++ b/backend/entries/templates/entries/entry_list_recents.html
@@ -1,0 +1,20 @@
+{% extends "entries/base.html" %}
+
+{% block content %}
+  <h3>Most Recent Entries</h2>
+
+  {% for entry in object_list %}
+  <article>
+    <h2 class="{{ entry.date_created|date:'l' }}">
+      {{ entry.date_created|date:'Y-m-d H:i' }}
+    </h2>
+    <h3>
+      <a href="{% url 'entry-detail' entry.id %}">
+        {{ entry.title }}
+      </a>
+    </h3>
+  </article>
+  {% empty %}
+  <p>No recent entries found.</p>
+  {% endfor %}
+  {% endblock content %}

--- a/backend/entries/urls.py
+++ b/backend/entries/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("", views.EntryListView.as_view(), name="entry-list"),
+    path("recent/", views.EntryRecentListView.as_view(), name="entry-recents"),
     path(
         "entry/<int:pk>", views.EntryDetailView.as_view(), name="entry-detail"
     ),

--- a/backend/entries/views.py
+++ b/backend/entries/views.py
@@ -50,3 +50,9 @@ class EntryDeleteView(LockedView, SuccessMessageMixin, DeleteView):
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
         return super().delete(request, *args, **kwargs)
+
+
+class EntryRecentListView(LockedView, ListView):
+    model = Entry
+    queryset = Entry.objects.all().order_by("-date_created")[:5]
+    template_name = "entries/entry_list_recents.html"

--- a/backend/entries/views.py
+++ b/backend/entries/views.py
@@ -54,5 +54,7 @@ class EntryDeleteView(LockedView, SuccessMessageMixin, DeleteView):
 
 class EntryRecentListView(LockedView, ListView):
     model = Entry
-    queryset = Entry.objects.all().order_by("-date_created")[:5]
     template_name = "entries/entry_list_recents.html"
+
+    def get_queryset(self):
+        return Entry.objects.all().order_by("-date_created")[:5]


### PR DESCRIPTION
This pull request introduces a new feature to display the five most recent entries in the LogBook application. The changes include updates to templates, views, and routing to support this functionality.

### New Feature: Recent Entries View

* **Added navigation links for recent entries**: Updated `entries/base.html` to include a navigation bar with links to "All Entries" and "Recent Entries." (`backend/entries/templates/entries/base.html`)
* **Created a template for recent entries**: Added a new template `entry_list_recents.html` to display the five most recent entries. It includes a fallback message if no entries are found. (`backend/entries/templates/entries/entry_list_recents.html`)
* **Added URL routing for recent entries**: Updated `urls.py` to include a new route `/recent/` for the `EntryRecentListView`. (`backend/entries/urls.py`)
* **Implemented a view for recent entries**: Created the `EntryRecentListView` class in `views.py` to fetch and display the five most recent entries, ordered by creation date. (`backend/entries/views.py`)