### PR TITLE
#8 - Add pagination to entry list template and view

### DIFF
--- a/backend/entries/templates/entries/entry_list.html
+++ b/backend/entries/templates/entries/entry_list.html
@@ -19,4 +19,32 @@
   </h3>
 </article>
 {% endfor %}
+
+{% if is_paginated %}
+<nav class="pagination">
+  <span>
+    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+  </span>
+  <div>
+    {% if page_obj.has_previous %}
+      <a href="?page=1">&laquo; First</a>
+      <a href="?page={{ page_obj.previous_page_number }}">Previous</a>
+    {% endif %}
+
+    {% for num in page_obj.paginator.page_range %}
+      {% if page_obj.number == num %}
+        <strong>{{ num }}</strong>
+      {% elif num > page_obj.number|add:'-3' and num < page_obj.number|add:'3' %}
+        <a href="?page={{ num }}">{{ num }}</a>
+      {% endif %}
+    {% endfor %}
+
+    {% if page_obj.has_next %}
+      <a href="?page={{ page_obj.next_page_number }}">Next</a>
+      <a href="?page={{ page_obj.paginator.num_pages }}">Last &raquo;</a>
+    {% endif %}
+  </div>
+</nav>
+{% endif %}
+
 {% endblock content %}

--- a/backend/entries/views.py
+++ b/backend/entries/views.py
@@ -20,6 +20,7 @@ class LockedView(LoginRequiredMixin):
 class EntryListView(LockedView, ListView):
     model = Entry
     queryset = Entry.objects.all().order_by("-date_created")
+    paginate_by = 10
 
 
 class EntryDetailView(LockedView, DetailView):


### PR DESCRIPTION
This pull request introduces pagination functionality to the entry list view in the backend. It includes updates to both the template and the view logic to support paginated navigation.

### Pagination Feature:

* **Template Update**: Added a pagination navigation section in the `entry_list.html` template. This includes links for navigating between pages, displaying the current page, and showing a range of nearby pages.
* **View Logic Update**: Added a `paginate_by` attribute to the `EntryListView` class in `views.py` to limit the number of entries displayed per page to 10.